### PR TITLE
Use extensions for GPU packages

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7' # Minimum required Julia version.
+          - '1.9' # Minimum required Julia version supporting extensions
           - '1'   # Latest stable 1.x release of Julia
           - 'nightly'
         os:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
         version:
           - '1.9' # Minimum required Julia version supporting extensions
           - '1'   # Latest stable 1.x release of Julia
-          - 'nightly'
+          # - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -26,4 +26,4 @@ StaticArrays = "1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "AMDGPU", "CUDA"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,16 +4,22 @@ authors = ["Samuel Omlin"]
 version = "0.1.4"
 
 [deps]
-AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
+[weakdeps]
+AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+
+[extensions]
+CellArrays_AMDGPUExt = "AMDGPU"
+CellArrays_CUDAExt = "CUDA"
+
 [compat]
-Adapt = "3"
+Adapt = "3" # TODO check v4
 AMDGPU = "0.3.7, 0.4, 0.5, 0.6, 0.7, 0.8"
 CUDA = "3.12, 4, 5"
-julia = "1.7"
+julia = "1.9" # Minimum version supporting extensions
 StaticArrays = "1"
 
 [extras]

--- a/examples/memcopyCellArray3D.jl
+++ b/examples/memcopyCellArray3D.jl
@@ -1,4 +1,5 @@
-using CellArrays, StaticArrays, CUDA
+using CUDA, StaticArrays
+using CellArrays
 
 function copy3D!(T2::CellArray, T::CellArray, Ci::CellArray)
     ix = (blockIdx().x-1) * blockDim().x + threadIdx().x

--- a/examples/memcopyCellArray3D_ParallelStencil.jl
+++ b/examples/memcopyCellArray3D_ParallelStencil.jl
@@ -1,4 +1,5 @@
 const USE_GPU = true
+import CUDA
 using CellArrays, StaticArrays
 using ParallelStencil
 using ParallelStencil.FiniteDifferences3D

--- a/ext/CellArrays_AMDGPUExt.jl
+++ b/ext/CellArrays_AMDGPUExt.jl
@@ -1,0 +1,4 @@
+module CellArrays_AMDGPUExt
+    include(joinpath(@__DIR__, "..", "src", "backends", "AMDGPU.jl"))
+    export ROCCellArray
+end

--- a/ext/CellArrays_CUDAExt.jl
+++ b/ext/CellArrays_CUDAExt.jl
@@ -1,0 +1,4 @@
+module CellArrays_CUDAExt
+    include(joinpath(@__DIR__, "..", "src", "backends", "CUDA.jl"))
+    export CuCellArray
+end # module

--- a/src/CellArray.jl
+++ b/src/CellArray.jl
@@ -1,4 +1,4 @@
-using StaticArrays, Adapt, CUDA, AMDGPU
+using StaticArrays, Adapt
 
 
 ## Constants
@@ -104,58 +104,12 @@ Construct an uninitialized `N`-dimensional `CellArray` containing `Cells` of typ
 
 See also: [`CellArray`](@ref), [`CuCellArray`](@ref), [`ROCCellArray`](@ref)
 """
-CPUCellArray{T,N,B,T_elem} = CellArray{T,N,B,Array{T_elem,_N}}
-
-
-"""
-    CuCellArray{T<:Cell,N,B,T_elem} <: AbstractArray{T,N} where Cell <: Union{Number, SArray, FieldArray}
-
-`N`-dimensional CellArray with cells of type `T`, blocklength `B`, and `T_array` being a `CuArray` of element type `T_elem`: alias for `CellArray{T,N,B,CuArray{T_elem,CellArrays._N}}`.
-
---------------------------------------------------------------------------------
-
-    CuCellArray{T,B}(undef, dims)
-    CuCellArray{T}(undef, dims)
-
-Construct an uninitialized `N`-dimensional `CellArray` containing `Cells` of type `T` which are stored in an array of kind `CuArray`.
-
-See also: [`CellArray`](@ref), [`CPUCellArray`](@ref), [`ROCCellArray`](@ref)
-"""
-CuCellArray{T,N,B,T_elem} = CellArray{T,N,B,CuArray{T_elem,_N}}
-
-
-"""
-    ROCCellArray{T<:Cell,N,B,T_elem} <: AbstractArray{T,N} where Cell <: Union{Number, SArray, FieldArray}
-
-`N`-dimensional CellArray with cells of type `T`, blocklength `B`, and `T_array` being a `ROCArray` of element type `T_elem`: alias for `CellArray{T,N,B,ROCArray{T_elem,CellArrays._N}}`.
-
---------------------------------------------------------------------------------
-
-    ROCCellArray{T,B}(undef, dims)
-    ROCCellArray{T}(undef, dims)
-
-Construct an uninitialized `N`-dimensional `CellArray` containing `Cells` of type `T` which are stored in an array of kind `ROCArray`.
-
-See also: [`CellArray`](@ref), [`CPUCellArray`](@ref), [`CuCellArray`](@ref)
-"""
-ROCCellArray{T,N,B,T_elem} = CellArray{T,N,B,ROCArray{T_elem,_N}}
-
+const CPUCellArray{T,N,B,T_elem} = CellArray{T,N,B,Array{T_elem,_N}}
 
 CPUCellArray{T,B}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N,B} = (check_T(T); CPUCellArray{T,N,B,eltype(T)}(undef, dims))
- CuCellArray{T,B}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N,B} = (check_T(T); CuCellArray{T,N,B,eltype(T)}(undef, dims))
-ROCCellArray{T,B}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N,B} = (check_T(T); ROCCellArray{T,N,B,eltype(T)}(undef, dims))
-
 CPUCellArray{T,B}(::UndefInitializer, dims::Int...) where {T<:Cell,B} = CPUCellArray{T,B}(undef, dims)
- CuCellArray{T,B}(::UndefInitializer, dims::Int...) where {T<:Cell,B} = CuCellArray{T,B}(undef, dims)
-ROCCellArray{T,B}(::UndefInitializer, dims::Int...) where {T<:Cell,B} = ROCCellArray{T,B}(undef, dims)
-
 CPUCellArray{T}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N} = CPUCellArray{T,0}(undef, dims)
- CuCellArray{T}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N} = CuCellArray{T,0}(undef, dims)
-ROCCellArray{T}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N} = ROCCellArray{T,0}(undef, dims)
-
 CPUCellArray{T}(::UndefInitializer, dims::Int...) where {T<:Cell} = CPUCellArray{T}(undef, dims)
- CuCellArray{T}(::UndefInitializer, dims::Int...) where {T<:Cell} = CuCellArray{T}(undef, dims)
-ROCCellArray{T}(::UndefInitializer, dims::Int...) where {T<:Cell} = ROCCellArray{T}(undef, dims)
 
 
 ## AbstractArray methods
@@ -168,14 +122,6 @@ ROCCellArray{T}(::UndefInitializer, dims::Int...) where {T<:Cell} = ROCCellArray
 
 @inline function Base.similar(A::CPUCellArray{T0,N0,B,T_elem0}, ::Type{T}, dims::NTuple{N,Int}) where {T0,N0,B,T_elem0,T<:Cell,N}
     CPUCellArray{T,N,B,eltype(T)}(undef, dims)
-end
-
-@inline function Base.similar(A::CuCellArray{T0,N0,B,T_elem0}, ::Type{T}, dims::NTuple{N,Int}) where {T0,N0,B,T_elem0,T<:Cell,N}
-    CuCellArray{T,N,B,eltype(T)}(undef, dims)
-end
-
-@inline function Base.similar(A::ROCCellArray{T0,N0,B,T_elem0}, ::Type{T}, dims::NTuple{N,Int}) where {T0,N0,B,T_elem0,T<:Cell,N}
-    ROCCellArray{T,N,B,eltype(T)}(undef, dims)
 end
 
 @inline function Base.similar(A::CellArray{T0,N0,B,T_array0}, ::Type{T}, dims::NTuple{N,Int}) where {T0,N0,B,T_array0,T<:Cell,N}

--- a/src/CellArrays.jl
+++ b/src/CellArrays.jl
@@ -31,5 +31,10 @@ using .Exceptions
 include("CellArray.jl")
 
 ## Exports (need to be after include of submodules if re-exports from them)
-export CellArray, CPUCellArray, CuCellArray, ROCCellArray, cellsize, blocklength, field
+export CellArray, CPUCellArray, cellsize, blocklength, field # Exported in extensions: CuCellArray, ROCCellArray # Not working!
+
+## Some function to show that extensions are working in general (relying on multiple dispatch).
+some_function(args...) = @ArgumentError("Required extension not loaded. Import CUDA/AMDGPU before using CellArrays with GPU features.")
+export some_function
+
 end

--- a/src/backends/AMDGPU.jl
+++ b/src/backends/AMDGPU.jl
@@ -1,0 +1,36 @@
+import CellArrays
+import CellArrays: CellArray, check_T, Cell, _N
+import AMDGPU: ROCArray
+
+"""
+    ROCCellArray{T<:Cell,N,B,T_elem} <: AbstractArray{T,N} where Cell <: Union{Number, SArray, FieldArray}
+
+`N`-dimensional CellArray with cells of type `T`, blocklength `B`, and `T_array` being a `ROCArray` of element type `T_elem`: alias for `CellArray{T,N,B,ROCArray{T_elem,CellArrays._N}}`.
+
+--------------------------------------------------------------------------------
+
+    ROCCellArray{T,B}(undef, dims)
+    ROCCellArray{T}(undef, dims)
+
+Construct an uninitialized `N`-dimensional `CellArray` containing `Cells` of type `T` which are stored in an array of kind `ROCArray`.
+
+See also: [`CellArray`](@ref), [`CPUCellArray`](@ref), [`CuCellArray`](@ref)
+"""
+const ROCCellArray{T,N,B,T_elem} = CellArray{T,N,B,ROCArray{T_elem,_N}}
+
+ROCCellArray{T,B}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N,B} = (check_T(T); ROCCellArray{T,N,B,eltype(T)}(undef, dims))
+ROCCellArray{T,B}(::UndefInitializer, dims::Int...) where {T<:Cell,B} = ROCCellArray{T,B}(undef, dims)
+ROCCellArray{T}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N} = ROCCellArray{T,0}(undef, dims)
+ROCCellArray{T}(::UndefInitializer, dims::Int...) where {T<:Cell} = ROCCellArray{T}(undef, dims)
+
+
+## AbstractArray methods
+
+@inline function Base.similar(A::ROCCellArray{T0,N0,B,T_elem0}, ::Type{T}, dims::NTuple{N,Int}) where {T0,N0,B,T_elem0,T<:Cell,N}
+    ROCCellArray{T,N,B,eltype(T)}(undef, dims)
+end
+
+
+## Some function to show that extensions are working in general
+
+CellArrays.some_function(A::ROCArray) = A .+ 1

--- a/src/backends/CUDA.jl
+++ b/src/backends/CUDA.jl
@@ -1,0 +1,36 @@
+import CellArrays
+import CellArrays: CellArray, check_T, Cell, _N
+import CUDA: CuArray
+
+"""
+    CuCellArray{T<:Cell,N,B,T_elem} <: AbstractArray{T,N} where Cell <: Union{Number, SArray, FieldArray}
+
+`N`-dimensional CellArray with cells of type `T`, blocklength `B`, and `T_array` being a `CuArray` of element type `T_elem`: alias for `CellArray{T,N,B,CuArray{T_elem,CellArrays._N}}`.
+
+--------------------------------------------------------------------------------
+
+    CuCellArray{T,B}(undef, dims)
+    CuCellArray{T}(undef, dims)
+
+Construct an uninitialized `N`-dimensional `CellArray` containing `Cells` of type `T` which are stored in an array of kind `CuArray`.
+
+See also: [`CellArray`](@ref), [`CPUCellArray`](@ref), [`ROCCellArray`](@ref)
+"""
+const CuCellArray{T,N,B,T_elem} = CellArray{T,N,B,CuArray{T_elem,_N}}
+
+CuCellArray{T,B}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N,B} = (check_T(T); CuCellArray{T,N,B,eltype(T)}(undef, dims))
+CuCellArray{T,B}(::UndefInitializer, dims::Int...) where {T<:Cell,B} = CuCellArray{T,B}(undef, dims)
+CuCellArray{T}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N} = CuCellArray{T,0}(undef, dims)
+CuCellArray{T}(::UndefInitializer, dims::Int...) where {T<:Cell} = CuCellArray{T}(undef, dims)
+
+
+## AbstractArray methods
+
+@inline function Base.similar(A::CuCellArray{T0,N0,B,T_elem0}, ::Type{T}, dims::NTuple{N,Int}) where {T0,N0,B,T_elem0,T<:Cell,N}
+    CuCellArray{T,N,B,eltype(T)}(undef, dims)
+end
+
+
+## Some function to show that extensions are working in general
+
+CellArrays.some_function(A::CuArray) = A .+ 1

--- a/test/test_CellArray.jl
+++ b/test/test_CellArray.jl
@@ -1,9 +1,13 @@
 using Test
 using CUDA, AMDGPU, StaticArrays
 import CellArrays
-import CellArrays: CPUCellArray, CuCellArray, ROCCellArray, cellsize, blocklength, _N
+# import CellArrays: CPUCellArray, CuCellArray, ROCCellArray, cellsize, blocklength, _N
+import CellArrays: CPUCellArray, cellsize, blocklength, _N
 import CellArrays: IncoherentArgumentError, ArgumentError
 
+# Aliases added has not yet working with extensions
+const CuCellArray{T,N,B,T_elem} = CellArray{T,N,B,CuArray{T_elem,_N}}
+const ROCCellArray{T,N,B,T_elem} = CellArray{T,N,B,ROCArray{T_elem,_N}}
 
 test_cuda = CUDA.functional()
 test_amdgpu = AMDGPU.functional()

--- a/test/test_CellArray.jl
+++ b/test/test_CellArray.jl
@@ -6,8 +6,8 @@ import CellArrays: CPUCellArray, cellsize, blocklength, _N
 import CellArrays: IncoherentArgumentError, ArgumentError
 
 # Aliases added has not yet working with extensions
-const CuCellArray{T,N,B,T_elem} = CellArray{T,N,B,CuArray{T_elem,_N}}
-const ROCCellArray{T,N,B,T_elem} = CellArray{T,N,B,ROCArray{T_elem,_N}}
+const CuCellArray{T,N,B,T_elem} = CellArrays.CellArray{T,N,B,CuArray{T_elem,_N}}
+const ROCCellArray{T,N,B,T_elem} = CellArrays.CellArray{T,N,B,ROCArray{T_elem,_N}}
 
 test_cuda = CUDA.functional()
 test_amdgpu = AMDGPU.functional()


### PR DESCRIPTION
This PR works except that the type aliases defined in the extensions cannot be made available to the user of the package (and it needs to be verified if the `similar` method defined has an effect). 

To illustrate that the extensions work in general, the function `some_function` was added temporarily. It works as shown here:
```julia
julia> using CUDA


julia> using CellArrays
[ Info: Precompiling CellArrays [d35fcfd7-7af4-4c67-b1aa-d78070614af4]
[ Info: Precompiling CellArrays_CUDAExt [0f7d8a02-766a-50ac-8bd6-eb945167c0c4]

julia> some_function(CUDA.zeros(2))
2-element CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}:
 1.0
 1.0
```

GPU unit tests pass (but only because the type aliases were defined directly in the test file):
```
Test Summary:     | Pass  Total   Time
test_CellArray.jl |  295    295  34.7s
     Testing CellArrays tests passed 
```