### PR TITLE
Remove GPU package dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
         version:
           - '1.9' # Minimum required Julia version (supporting extensions)
           - '1'   # Latest stable 1.x release of Julia
-          - 'nightly'
+          #- 'nightly' # CUDA fails to pre-compile on nightly
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7' # Minimum required Julia version.
+          - '1.9' # Minimum required Julia version (supporting extensions)
           - '1'   # Latest stable 1.x release of Julia
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -4,20 +4,24 @@ authors = ["Samuel Omlin"]
 version = "0.1.4"
 
 [deps]
-AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
+# [weakdeps]
+# AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+# CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+
 [compat]
-Adapt = "3"
-AMDGPU = "0.3.7, 0.4, 0.5, 0.6, 0.7, 0.8"
-CUDA = "3.12, 4, 5"
-julia = "1.7"
+Adapt = "3" #TODO: , 4"
+# AMDGPU = "0.3.7, 0.4, 0.5, 0.6, 0.7, 0.8"
+# CUDA = "3.12, 4, 5"
+julia = "1.9" # Minimum required Julia version (supporting extensions)
 StaticArrays = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [targets]
-test = ["Test"]
+test = ["Test", "AMDGPU", "CUDA"]

--- a/examples/memcopyCellArray3D.jl
+++ b/examples/memcopyCellArray3D.jl
@@ -1,5 +1,7 @@
 using CellArrays, StaticArrays, CUDA
 
+@define_CuCellArray
+
 function copy3D!(T2::CellArray, T::CellArray, Ci::CellArray)
     ix = (blockIdx().x-1) * blockDim().x + threadIdx().x
     iy = (blockIdx().y-1) * blockDim().y + threadIdx().y

--- a/examples/memcopyCellArray3D_ParallelStencil.jl
+++ b/examples/memcopyCellArray3D_ParallelStencil.jl
@@ -1,5 +1,6 @@
 const USE_GPU = true
 using CellArrays, StaticArrays
+import CUDA
 using ParallelStencil
 using ParallelStencil.FiniteDifferences3D
 @static if USE_GPU

--- a/src/CellArrays.jl
+++ b/src/CellArrays.jl
@@ -6,11 +6,11 @@ Provides support for an AbstractArray subtype `CellArray`, which represents arra
 # General overview and examples
 https://github.com/omlins/CellArray.jl
 
-# Constructors
+# Constructors and type aliases
 - [`CellArray`](@ref)
 - [`CPUCellArray`](@ref)
-- [`CuCellArray`](@ref)
-- [`ROCCellArray`](@ref)
+- `CuCellArray` (available via [`@define_CuCellArray`](@ref))
+- `ROCCellArray` (available via [`@define_ROCCellArray`](@ref))
 
 # Functions (additional to standard AbstractArray functionality)
 - [`cellsize`](@ref)
@@ -31,5 +31,5 @@ using .Exceptions
 include("CellArray.jl")
 
 ## Exports (need to be after include of submodules if re-exports from them)
-export CellArray, @CPUCellArray, @CuCellArray, @ROCCellArray, cellsize, blocklength, field
+export CellArray, CPUCellArray, @define_CuCellArray, @define_ROCCellArray, cellsize, blocklength, field
 end

--- a/src/CellArrays.jl
+++ b/src/CellArrays.jl
@@ -31,5 +31,5 @@ using .Exceptions
 include("CellArray.jl")
 
 ## Exports (need to be after include of submodules if re-exports from them)
-export CellArray, CPUCellArray, CuCellArray, ROCCellArray, cellsize, blocklength, field
+export CellArray, @CPUCellArray, @CuCellArray, @ROCCellArray, cellsize, blocklength, field
 end

--- a/test/test_CellArray.jl
+++ b/test/test_CellArray.jl
@@ -1,21 +1,11 @@
 using Test
 using CUDA, AMDGPU, StaticArrays
 import CellArrays
-import CellArrays: @CPUCellArray, @CuCellArray, @ROCCellArray, cellsize, blocklength, _N, Cell
+import CellArrays: CPUCellArray, @define_CuCellArray, @define_ROCCellArray, cellsize, blocklength, _N
 import CellArrays: IncoherentArgumentError, ArgumentError
 
-const CPUCellArray{T,N,B,T_elem} = @CPUCellArray(T,N,B,T_elem)
-const CuCellArray{T,N,B,T_elem}  = @CuCellArray(T,N,B,T_elem)
-const ROCCellArray{T,N,B,T_elem} = @ROCCellArray(T,N,B,T_elem)
-
-const CPUCellArray{T,B}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N,B} = @CPUCellArray(T,B,dims)
-const  CuCellArray{T,B}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N,B} = @CuCellArray(T,B,dims)
-const ROCCellArray{T,B}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N,B} = @ROCCellArray(T,B,dims)
-
-const CPUCellArray{T  }(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N  } = @CPUCellArray(T,dims)
-const  CuCellArray{T  }(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N  } = @CuCellArray(T,dims)
-const ROCCellArray{T  }(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N  } = @ROCCellArray(T,dims)
-
+@define_CuCellArray
+@define_ROCCellArray
 
 test_cuda = CUDA.functional()
 test_amdgpu = AMDGPU.functional()

--- a/test/test_CellArray.jl
+++ b/test/test_CellArray.jl
@@ -1,8 +1,20 @@
 using Test
 using CUDA, AMDGPU, StaticArrays
 import CellArrays
-import CellArrays: CPUCellArray, CuCellArray, ROCCellArray, cellsize, blocklength, _N
+import CellArrays: @CPUCellArray, @CuCellArray, @ROCCellArray, cellsize, blocklength, _N, Cell
 import CellArrays: IncoherentArgumentError, ArgumentError
+
+const CPUCellArray{T,N,B,T_elem} = @CPUCellArray(T,N,B,T_elem)
+const CuCellArray{T,N,B,T_elem}  = @CuCellArray(T,N,B,T_elem)
+const ROCCellArray{T,N,B,T_elem} = @ROCCellArray(T,N,B,T_elem)
+
+const CPUCellArray{T,B}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N,B} = @CPUCellArray(T,B,dims)
+const  CuCellArray{T,B}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N,B} = @CuCellArray(T,B,dims)
+const ROCCellArray{T,B}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N,B} = @ROCCellArray(T,B,dims)
+
+const CPUCellArray{T  }(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N  } = @CPUCellArray(T,dims)
+const  CuCellArray{T  }(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N  } = @CuCellArray(T,dims)
+const ROCCellArray{T  }(::UndefInitializer, dims::NTuple{N,Int}) where {T<:Cell,N  } = @ROCCellArray(T,dims)
 
 
 test_cuda = CUDA.functional()


### PR DESCRIPTION
The current state of Julia's extensions feature does not seem to provide a good way to make type aliases from the extensions available to the user (see #25 ). Given that type aliases are the only feature of CellArrays that actually require to import the GPU packages and therefore to create a dependency, we can provide the corresponding functionality using macros instead and then completely remove the GPU package dependencies.