### PR TITLE
Add support for Metal arrays with `MtlCellArray`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,11 +10,13 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [weakdeps]
 AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
 
 [compat]
 Adapt = "3, 4"
 AMDGPU = "0.3.7, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1"
 CUDA = "3.12, 4, 5"
+Metal = "1"
 julia = "1.9" # Minimum required Julia version (supporting extensions and weak dependencies)
 StaticArrays = "1"
 
@@ -22,4 +24,4 @@ StaticArrays = "1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "AMDGPU", "CUDA"]
+test = ["Test", "AMDGPU", "CUDA", "Metal"]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -5,17 +5,47 @@ git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
 uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
 version = "0.0.1"
 
+[[Adapt]]
+deps = ["LinearAlgebra", "Requires"]
+git-tree-sha1 = "6a55b747d1812e699320963ffde36f1ebdda4099"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "4.0.4"
+weakdeps = ["StaticArrays"]
+
+    [Adapt.extensions]
+    AdaptStaticArraysExt = "StaticArrays"
+
+[[Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CellArrays]]
+deps = ["Adapt", "StaticArrays"]
 path = ".."
 uuid = "d35fcfd7-7af4-4c67-b1aa-d78070614af4"
-version = "0.1.0"
+version = "0.2.2"
+
+    [CellArrays.weakdeps]
+    AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+
+[[CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.1.1+0"
 
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DocExtensions]]
+deps = ["Markdown"]
+git-tree-sha1 = "bf4634dffad1ede92b9deca91262c75c000e47ca"
+uuid = "cbdad009-89f1-4e05-85a0-06b07b50707d"
+version = "0.2.0"
 
 [[DocStringExtensions]]
 deps = ["LibGit2"]
@@ -46,8 +76,25 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.3"
 
 [[LibGit2]]
-deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.6.4+0"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.0+1"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -56,17 +103,40 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.2+1"
+
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
+[[OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.23+4"
 
 [[Parsers]]
 deps = ["Dates"]
 git-tree-sha1 = "621f4f3b4977325b9128d5fae7a8b4829a0c2222"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "2.2.4"
+
+[[PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.1"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.3"
 
 [[Printf]]
 deps = ["Unicode"]
@@ -77,11 +147,18 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
-deps = ["Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.0"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -89,9 +166,42 @@ uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
+[[StaticArrays]]
+deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
+git-tree-sha1 = "eeafab08ae20c62c44c8399ccb9354a04b80db50"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.9.7"
+
+    [StaticArrays.extensions]
+    StaticArraysChainRulesCoreExt = "ChainRulesCore"
+    StaticArraysStatisticsExt = "Statistics"
+
+    [StaticArrays.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[StaticArraysCore]]
+git-tree-sha1 = "192954ef1208c7019899fbf8049e717f92959682"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.3"
+
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
 [[Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.11.0+0"

--- a/src/CellArray.jl
+++ b/src/CellArray.jl
@@ -188,6 +188,44 @@ function define_ROCCellArray()
     end
 end
 
+"""
+    @define_MtlCellArray
+
+Define the following type alias and constructors in the caller module:
+
+********************************************************************************
+    MtlCellArray{T<:Cell,N,B,T_elem} <: AbstractArray{T,N} where Cell <: Union{Number, SArray, FieldArray}
+
+`N`-dimensional CellArray with cells of type `T`, blocklength `B`, and `T_array` being a `MtlArray` of element type `T_elem`: alias for `CellArray{T,N,B,MtlArray{T_elem,CellArrays._N}}`.
+
+--------------------------------------------------------------------------------
+
+    MtlCellArray{T,B}(undef, dims)
+    MtlCellArray{T}(undef, dims)
+
+Construct an uninitialized `N`-dimensional `CellArray` containing `Cells` of type `T` which are stored in an array of kind `MtlArray`.
+
+See also: [`CellArray`](@ref), [`CPUCellArray`](@ref), [`CuCellArray`](@ref), [`ROCCellArray`](@ref)
+********************************************************************************
+
+!!! note "Avoiding unneeded dependencies"
+    The type aliases and constructors for GPU `CellArray`s are provided via macros to avoid unneeded dependencies on the GPU packages in CellArrays.
+
+See also: [`@define_CuCellArray`](@ref), [`@define_ROCCellArray`](@ref)
+"""
+macro define_MtlCellArray() esc(define_MtlCellArray()) end
+
+function define_MtlCellArray()
+    quote
+        const MtlCellArray{T,N,B,T_elem} = CellArrays.CellArray{T,N,B,Metal.MtlArray{T_elem,CellArrays._N}}
+
+        MtlCellArray{T,B}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:CellArrays.Cell,N,B} = (CellArrays.check_T(T); MtlCellArray{T,N,B,CellArrays.eltype(T)}(undef, dims))
+        MtlCellArray{T,B}(::UndefInitializer, dims::Int...) where {T<:CellArrays.Cell,B} = MtlCellArray{T,B}(undef, dims)
+        MtlCellArray{T}(::UndefInitializer, dims::NTuple{N,Int}) where {T<:CellArrays.Cell,N} = MtlCellArray{T,0}(undef, dims)
+        MtlCellArray{T}(::UndefInitializer, dims::Int...) where {T<:CellArrays.Cell} = MtlCellArray{T}(undef, dims)
+    end
+end
+
 
 ## AbstractArray methods
 

--- a/src/CellArrays.jl
+++ b/src/CellArrays.jl
@@ -11,6 +11,7 @@ https://github.com/omlins/CellArray.jl
 - [`CPUCellArray`](@ref)
 - `CuCellArray` (available via [`@define_CuCellArray`](@ref))
 - `ROCCellArray` (available via [`@define_ROCCellArray`](@ref))
+- `MtlCellArray` (available via [`@define_MtlCellArray`](@ref))
 
 # Functions (additional to standard AbstractArray functionality)
 - [`cellsize`](@ref)
@@ -31,5 +32,5 @@ using .Exceptions
 include("CellArray.jl")
 
 ## Exports (need to be after include of submodules if re-exports from them)
-export CellArray, CPUCellArray, @define_CuCellArray, @define_ROCCellArray, cellsize, blocklength, field
+export CellArray, CPUCellArray, @define_CuCellArray, @define_ROCCellArray, @define_MtlCellArray, cellsize, blocklength, field
 end

--- a/test/test_CellArray.jl
+++ b/test/test_CellArray.jl
@@ -1,5 +1,5 @@
 using Test
-using CUDA, AMDGPU, StaticArrays
+using CUDA, AMDGPU, Metal, StaticArrays
 import CellArrays
 import CellArrays: CPUCellArray, @define_CuCellArray, @define_ROCCellArray, @define_MtlCellArray, cellsize, blocklength, _N
 import CellArrays: IncoherentArgumentError, ArgumentError
@@ -8,9 +8,9 @@ import CellArrays: IncoherentArgumentError, ArgumentError
 @define_ROCCellArray
 @define_MtlCellArray
 
-test_cuda = (@static CUDA.functional() ? true : false)
-test_amdgpu = (@static AMDGPU.functional() ? true : false)
-test_metal = (@static Metal.functional() ? true : false)
+test_cuda = CUDA.functional()
+test_amdgpu = AMDGPU.functional()
+test_metal = Metal.functional()
 
 array_types           = ["CPU"]
 ArrayConstructors     = [Array]

--- a/test/test_CellArray.jl
+++ b/test/test_CellArray.jl
@@ -1,14 +1,16 @@
 using Test
 using CUDA, AMDGPU, StaticArrays
 import CellArrays
-import CellArrays: CPUCellArray, @define_CuCellArray, @define_ROCCellArray, cellsize, blocklength, _N
+import CellArrays: CPUCellArray, @define_CuCellArray, @define_ROCCellArray, @define_MtlCellArray, cellsize, blocklength, _N
 import CellArrays: IncoherentArgumentError, ArgumentError
 
 @define_CuCellArray
 @define_ROCCellArray
+@define_MtlCellArray
 
-test_cuda = CUDA.functional()
-test_amdgpu = AMDGPU.functional()
+test_cuda = (@static CUDA.functional() ? true : false)
+test_amdgpu = (@static AMDGPU.functional() ? true : false)
+test_metal = (@static Metal.functional() ? true : false)
 
 array_types           = ["CPU"]
 ArrayConstructors     = [Array]
@@ -27,6 +29,13 @@ if test_amdgpu
 	push!(ArrayConstructors, ROCArray)
 	push!(CellArrayConstructors, ROCCellArray)
 	push!(allowscalar_functions, AMDGPU.allowscalar) #TODO: to be implemented
+end
+if test_metal
+	metalzeros = Metal.zeros
+	push!(array_types, "Metal")
+	push!(ArrayConstructors, MtlArray)
+	push!(CellArrayConstructors, MtlCellArray)
+	push!(allowscalar_functions, Metal.allowscalar) #TODO: to be implemented
 end
 
 struct MyFieldArray{T} <: FieldArray{Tuple{2,2,2,2}, T, 4}
@@ -53,30 +62,34 @@ mutable struct MyMutableFieldArray{T} <: FieldArray{Tuple{2}, T, 1}
     yxxx::T
 end
 
+const TEST_PRECISIONS = [Float32, Float64]
+for (array_type, Array, CellArray, allowscalar) in zip(array_types, ArrayConstructors, CellArrayConstructors, allowscalar_functions)
+for DataType in TEST_PRECISIONS
+(array_type == "Metal" && DataType == Float64) ? continue : nothing # Metal does not support DataType
 
-@testset "$(basename(@__FILE__))" begin
-    @testset "1. CellArray allocation ($array_type arrays)" for (array_type, Array, CellArray) in zip(array_types, ArrayConstructors, CellArrayConstructors)
+@testset "$(basename(@__FILE__)) ($array_type arrays) (precision: $DataType)" begin
+    @testset "1. CellArray allocation ($array_type arrays) (precision: $DataType)" begin
         @testset "Number cells" begin
 			dims = (2,3)
-			A = CellArray{Float64}(undef, dims)
+			A = CellArray{DataType}(undef, dims)
 			B = CellArrays.CellArray{Int32,prod(dims)}(Array, undef, dims...)
-			C = CellArray{Float64,1}(undef, dims)
+			C = CellArray{DataType,1}(undef, dims)
 			D = CellArray{Int32,4}(undef, dims)
 			@test typeof(A.data) <: Array
 			@test typeof(B.data) <: Array
 			@test typeof(C.data) <: Array
 			@test typeof(D.data) <: Array
-			@test eltype(A.data) == Float64
+			@test eltype(A.data) == DataType
 			@test eltype(B.data) == Int32
-			@test eltype(C.data) == Float64
+			@test eltype(C.data) == DataType
 			@test eltype(D.data) == Int32
-			@test eltype(A)      == Float64
+			@test eltype(A)      == DataType
 			@test eltype(B)      == Int32
-			@test eltype(C)      == Float64
+			@test eltype(C)      == DataType
 			@test eltype(D)      == Int32
-			@test typeof(A)      == CellArrays.CellArray{Float64, length(dims), 0, Array{eltype(A.data),_N}}
+			@test typeof(A)      == CellArrays.CellArray{DataType, length(dims), 0, Array{eltype(A.data),_N}}
 			@test typeof(B)      == CellArrays.CellArray{Int32, length(dims), prod(dims), Array{eltype(B.data),_N}}
-			@test typeof(C)      == CellArrays.CellArray{Float64, length(dims), 1, Array{eltype(C.data),_N}}
+			@test typeof(C)      == CellArrays.CellArray{DataType, length(dims), 1, Array{eltype(C.data),_N}}
 			@test typeof(D)      == CellArrays.CellArray{Int32, length(dims), 4, Array{eltype(D.data),_N}}
 			@test length(A.data) == prod(dims)
 			@test length(B.data) == prod(dims)
@@ -90,27 +103,27 @@ end
 		@testset "SArray cells" begin
 			dims      = (2,3)
 			celldims  = (3,4)
-			T_Float64 = SMatrix{celldims..., Float64, prod(celldims)}
+			T_DataType = SMatrix{celldims..., DataType, prod(celldims)}
 			T_Int32   = SMatrix{celldims...,   Int32, prod(celldims)}
-			A = CellArray{T_Float64}(undef, dims)
+			A = CellArray{T_DataType}(undef, dims)
 			B = CellArrays.CellArray{T_Int32,prod(dims)}(Array, undef, dims...)
-			C = CellArray{T_Float64,1}(undef, dims)
+			C = CellArray{T_DataType,1}(undef, dims)
 			D = CellArray{T_Int32,4}(undef, dims)
 			@test typeof(A.data) <: Array
 			@test typeof(B.data) <: Array
 			@test typeof(C.data) <: Array
 			@test typeof(D.data) <: Array
-			@test eltype(A.data) == Float64
+			@test eltype(A.data) == DataType
 			@test eltype(B.data) == Int32
-			@test eltype(C.data) == Float64
+			@test eltype(C.data) == DataType
 			@test eltype(D.data) == Int32
-			@test eltype(A)      == T_Float64
+			@test eltype(A)      == T_DataType
 			@test eltype(B)      == T_Int32
-			@test eltype(C)      == T_Float64
+			@test eltype(C)      == T_DataType
 			@test eltype(D)      == T_Int32
-			@test typeof(A)      == CellArrays.CellArray{T_Float64, length(dims), 0, Array{eltype(A.data),_N}}
+			@test typeof(A)      == CellArrays.CellArray{T_DataType, length(dims), 0, Array{eltype(A.data),_N}}
 			@test typeof(B)      == CellArrays.CellArray{T_Int32, length(dims), prod(dims), Array{eltype(B.data),_N}}
-			@test typeof(C)      == CellArrays.CellArray{T_Float64, length(dims), 1, Array{eltype(C.data),_N}}
+			@test typeof(C)      == CellArrays.CellArray{T_DataType, length(dims), 1, Array{eltype(C.data),_N}}
 			@test typeof(D)      == CellArrays.CellArray{T_Int32, length(dims), 4, Array{eltype(D.data),_N}}
 			@test length(A.data) == prod(dims)*prod(celldims)
 			@test length(B.data) == prod(dims)*prod(celldims)
@@ -124,27 +137,27 @@ end
 		@testset "FieldArray cells" begin
 			dims      = (2,3)
 			celldims  = size(MyFieldArray)
-			T_Float64 = MyFieldArray{Float64}
+			T_DataType = MyFieldArray{DataType}
 			T_Int32   = MyFieldArray{Int32}
-			A = CellArray{T_Float64}(undef, dims)
+			A = CellArray{T_DataType}(undef, dims)
 			B = CellArrays.CellArray{T_Int32,prod(dims)}(Array, undef, dims...)
-			C = CellArray{T_Float64,1}(undef, dims)
+			C = CellArray{T_DataType,1}(undef, dims)
 			D = CellArray{T_Int32,4}(undef, dims)
 			@test typeof(A.data) <: Array
 			@test typeof(B.data) <: Array
 			@test typeof(C.data) <: Array
 			@test typeof(D.data) <: Array
-			@test eltype(A.data) == Float64
+			@test eltype(A.data) == DataType
 			@test eltype(B.data) == Int32
-			@test eltype(C.data) == Float64
+			@test eltype(C.data) == DataType
 			@test eltype(D.data) == Int32
-			@test eltype(A)      == T_Float64
+			@test eltype(A)      == T_DataType
 			@test eltype(B)      == T_Int32
-			@test eltype(C)      == T_Float64
+			@test eltype(C)      == T_DataType
 			@test eltype(D)      == T_Int32
-			@test typeof(A)      == CellArrays.CellArray{T_Float64, length(dims), 0, Array{eltype(A.data),_N}}
+			@test typeof(A)      == CellArrays.CellArray{T_DataType, length(dims), 0, Array{eltype(A.data),_N}}
 			@test typeof(B)      == CellArrays.CellArray{T_Int32, length(dims), prod(dims), Array{eltype(B.data),_N}}
-			@test typeof(C)      == CellArrays.CellArray{T_Float64, length(dims), 1, Array{eltype(C.data),_N}}
+			@test typeof(C)      == CellArrays.CellArray{T_DataType, length(dims), 1, Array{eltype(C.data),_N}}
 			@test typeof(D)      == CellArrays.CellArray{T_Int32, length(dims), 4, Array{eltype(D.data),_N}}
 			@test length(A.data) == prod(dims)*prod(celldims)
 			@test length(B.data) == prod(dims)*prod(celldims)
@@ -156,20 +169,20 @@ end
 			@test D.dims         == dims
         end;
     end;
-	@testset "2. functions ($array_type arrays)" for (array_type, Array, CellArray, allowscalar) in zip(array_types, ArrayConstructors, CellArrayConstructors, allowscalar_functions)
+	@testset "2. functions ($array_type arrays)" begin
 		dims      = (2,3)
 		celldims  = (3,4) # Needs to be compatible for matrix multiplication!
-		T_Float64 = SMatrix{celldims..., Float64, prod(celldims)}
+		T_DataType = SMatrix{celldims..., DataType, prod(celldims)}
 		T_Int32   = SMatrix{celldims...,   Int32, prod(celldims)}
-		T2_Float64 = MyFieldArray{Float64}
+		T2_DataType = MyFieldArray{DataType}
 		T2_Int32   = MyFieldArray{Int32}
-		A = CellArray{Float64}(undef, dims)
+		A = CellArray{DataType}(undef, dims)
 		B = CellArrays.CellArray{Int32,prod(dims)}(Array, undef, dims)
-		C = CellArray{T_Float64}(undef, dims)
+		C = CellArray{T_DataType}(undef, dims)
 		D = CellArray{T_Int32,prod(dims)}(undef, dims)
-		E = CellArray{T2_Float64}(undef, dims)
+		E = CellArray{T2_DataType}(undef, dims)
 		F = CellArray{T2_Int32,prod(dims)}(undef, dims)
-		G = CellArray{T_Float64,1}(undef, dims)
+		G = CellArray{T_DataType,1}(undef, dims)
 		H = CellArray{T_Int32,4}(undef, dims)
         @testset "size" begin
 			@test size(A) == dims
@@ -200,37 +213,37 @@ end
 			@test typeof(similar(H, T_Int32, (1,2))) == CellArrays.CellArray{T_Int32, 2, blocklength(H), Array{eltype(T_Int32),_N}}
         end;
 		@testset "fill!" begin
-			allowscalar(true)
-			fill!(A, 9);   @test all(Base.Array(A.data) .== 9.0)
-			fill!(B, 9.0); @test all(Base.Array(B.data) .== 9)
-			fill!(C, (1:length(eltype(C)))); @test all(C .== (T_Float64(1:length(eltype(C)))  for i=1:dims[1], j=1:dims[2]))
-			fill!(D, (1:length(eltype(D)))); @test all(D .== (T_Int32(1:length(eltype(D)))    for i=1:dims[1], j=1:dims[2]))
-			fill!(E, (1:length(eltype(E)))); @test all(E .== (T2_Float64(1:length(eltype(E))) for i=1:dims[1], j=1:dims[2]))
-			fill!(F, (1:length(eltype(F)))); @test all(F .== (T2_Int32(1:length(eltype(F)))   for i=1:dims[1], j=1:dims[2]))
-			fill!(G, (1:length(eltype(G)))); @test all(G .== (T_Float64(1:length(eltype(G)))  for i=1:dims[1], j=1:dims[2]))
-			fill!(H, (1:length(eltype(H)))); @test all(H .== (T_Int32(1:length(eltype(H)))    for i=1:dims[1], j=1:dims[2]))
-			allowscalar(false)
+			allowscalar() do
+				fill!(A, 9);   @test all(Base.Array(A.data) .== 9.0)
+				fill!(B, 9.0); @test all(Base.Array(B.data) .== 9)
+				fill!(C, (1:length(eltype(C)))); @test all(C .== (T_DataType(1:length(eltype(C)))  for i=1:dims[1], j=1:dims[2]))
+				fill!(D, (1:length(eltype(D)))); @test all(D .== (T_Int32(1:length(eltype(D)))    for i=1:dims[1], j=1:dims[2]))
+				fill!(E, (1:length(eltype(E)))); @test all(E .== (T2_DataType(1:length(eltype(E))) for i=1:dims[1], j=1:dims[2]))
+				fill!(F, (1:length(eltype(F)))); @test all(F .== (T2_Int32(1:length(eltype(F)))   for i=1:dims[1], j=1:dims[2]))
+				fill!(G, (1:length(eltype(G)))); @test all(G .== (T_DataType(1:length(eltype(G)))  for i=1:dims[1], j=1:dims[2]))
+				fill!(H, (1:length(eltype(H)))); @test all(H .== (T_Int32(1:length(eltype(H)))    for i=1:dims[1], j=1:dims[2]))
+			end
 		end
 		@testset "getindex / setindex! (array programming)" begin
-			allowscalar(true)
-			A.data.=0; B.data.=0; C.data.=0; D.data.=0; E.data.=0; F.data.=0; G.data.=0; H.data.=0;
-			A[2,2:3] .= 9
-			B[2,2:3] .= 9.0
-			C[2,2:3] .= (T_Float64(1:length(T_Float64)), T_Float64(1:length(T_Float64)))
-			D[2,2:3] .= (T_Int32(1:length(T_Int32)), T_Int32(1:length(T_Int32)))
-			E[2,2:3] .= (T2_Float64(1:length(T2_Float64)), T2_Float64(1:length(T2_Float64)))
-			F[2,2:3] .= (T2_Int32(1:length(T2_Int32)), T2_Int32(1:length(T2_Int32)))
-			G[2,2:3] .= (T_Float64(1:length(T_Float64)), T_Float64(1:length(T_Float64)))
-			H[2,2:3] .= (T_Int32(1:length(T_Int32)), T_Int32(1:length(T_Int32)))
-			@test all(A[2,2:3] .== 9.0)
-			@test all(B[2,2:3] .== 9)
-			@test all(C[2,2:3] .== (T_Float64(1:length(T_Float64)), T_Float64(1:length(T_Float64))))
-			@test all(D[2,2:3] .== (T_Int32(1:length(T_Int32)), T_Int32(1:length(T_Int32))))
-			@test all(E[2,2:3] .== (T2_Float64(1:length(T2_Float64)), T2_Float64(1:length(T2_Float64))))
-			@test all(F[2,2:3] .== (T2_Int32(1:length(T2_Int32)), T2_Int32(1:length(T2_Int32))))
-			@test all(G[2,2:3] .== (T_Float64(1:length(T_Float64)), T_Float64(1:length(T_Float64))))
-			@test all(H[2,2:3] .== (T_Int32(1:length(T_Int32)), T_Int32(1:length(T_Int32))))
-			allowscalar(false)
+			allowscalar() do
+				A.data.=0; B.data.=0; C.data.=0; D.data.=0; E.data.=0; F.data.=0; G.data.=0; H.data.=0;
+				A[2,2:3] .= 9
+				B[2,2:3] .= 9.0
+				C[2,2:3] .= (T_DataType(1:length(T_DataType)), T_DataType(1:length(T_DataType)))
+				D[2,2:3] .= (T_Int32(1:length(T_Int32)), T_Int32(1:length(T_Int32)))
+				E[2,2:3] .= (T2_DataType(1:length(T2_DataType)), T2_DataType(1:length(T2_DataType)))
+				F[2,2:3] .= (T2_Int32(1:length(T2_Int32)), T2_Int32(1:length(T2_Int32)))
+				G[2,2:3] .= (T_DataType(1:length(T_DataType)), T_DataType(1:length(T_DataType)))
+				H[2,2:3] .= (T_Int32(1:length(T_Int32)), T_Int32(1:length(T_Int32)))
+				@test all(A[2,2:3] .== 9.0)
+				@test all(B[2,2:3] .== 9)
+				@test all(C[2,2:3] .== (T_DataType(1:length(T_DataType)), T_DataType(1:length(T_DataType))))
+				@test all(D[2,2:3] .== (T_Int32(1:length(T_Int32)), T_Int32(1:length(T_Int32))))
+				@test all(E[2,2:3] .== (T2_DataType(1:length(T2_DataType)), T2_DataType(1:length(T2_DataType))))
+				@test all(F[2,2:3] .== (T2_Int32(1:length(T2_Int32)), T2_Int32(1:length(T2_Int32))))
+				@test all(G[2,2:3] .== (T_DataType(1:length(T_DataType)), T_DataType(1:length(T_DataType))))
+				@test all(H[2,2:3] .== (T_Int32(1:length(T_Int32)), T_Int32(1:length(T_Int32))))
+			end
         end;
 		@testset "getindex / setindex! (GPU kernel programming)" begin
 			celldims2 = (4,4) # Needs to be compatible for matrix multiplication!
@@ -254,22 +267,39 @@ end
 				J.data.=3; J_ref.data.=36; @cuda blocks=size(J) matsquare2D_CUDA!(J); CUDA.synchronize(); @test CUDA.@allowscalar all(J .== J_ref)
 				C.data.=2; G.data.=3;      @cuda blocks=size(C) add2D_CUDA!(C, G);    CUDA.synchronize(); @test all(Base.Array(C.data) .== 5)
 			end
-			if array_type == "AMDGPU"
-				function add2D_AMDGPU!(A, B)
-				    ix = (AMDGPU.blockIdx().x-1) * AMDGPU.blockDim().x + AMDGPU.threadIdx().x
-				    iy = (AMDGPU.blockIdx().y-1) * AMDGPU.blockDim().y + AMDGPU.threadIdx().y
+			# if array_type == "AMDGPU"
+			# 	function add2D_AMDGPU!(A, B)
+			# 	    ix = (AMDGPU.blockIdx().x-1) * AMDGPU.blockDim().x + AMDGPU.threadIdx().x
+			# 	    iy = (AMDGPU.blockIdx().y-1) * AMDGPU.blockDim().y + AMDGPU.threadIdx().y
+			# 	    A[ix,iy] = A[ix,iy] + B[ix,iy];
+			# 	    return
+			# 	end
+			# 	function matsquare2D_AMDGPU!(A)
+			# 	    ix = (AMDGPU.blockIdx().x-1) * AMDGPU.blockDim().x + AMDGPU.threadIdx().x
+			# 	    iy = (AMDGPU.blockIdx().y-1) * AMDGPU.blockDim().y + AMDGPU.threadIdx().y
+			# 		A[ix,iy] = A[ix,iy] * A[ix,iy];
+			# 	    return
+			# 	end
+			# 	A.data.=3;                 @roc gridsize=size(A) matsquare2D_AMDGPU!(A); AMDGPU.synchronize(); @test all(Base.Array(A.data) .== 9)
+			# 	J.data.=3; J_ref.data.=36; @roc gridsize=size(J) matsquare2D_AMDGPU!(J); AMDGPU.synchronize(); @test AMDGPU.@allowscalar all(J .== J_ref)
+			# 	C.data.=2; G.data.=3;      @roc gridsize=size(C) add2D_AMDGPU!(C, G);    AMDGPU.synchronize(); @test all(Base.Array(C.data) .== 5)
+			# end
+			if array_type == "Metal"
+				function add2D_Metal!(A, B)
+				    ix = (Metal.threadgroup_position_in_grid_3d().x-1) * Metal.threads_per_threadgroup_3d().x + Metal.thread_position_in_threadgroup_3d().x
+				    iy = (Metal.threadgroup_position_in_grid_3d().y-1) * Metal.threads_per_threadgroup_3d().y + Metal.thread_position_in_threadgroup_3d().y
 				    A[ix,iy] = A[ix,iy] + B[ix,iy];
 				    return
 				end
-				function matsquare2D_AMDGPU!(A)
-				    ix = (AMDGPU.blockIdx().x-1) * AMDGPU.blockDim().x + AMDGPU.threadIdx().x
-				    iy = (AMDGPU.blockIdx().y-1) * AMDGPU.blockDim().y + AMDGPU.threadIdx().y
+				function matsquare2D_Metal!(A)
+				    ix = (Metal.threadgroup_position_in_grid_3d().x-1) * Metal.threads_per_threadgroup_3d().x + Metal.thread_position_in_threadgroup_3d().x
+				    iy = (Metal.threadgroup_position_in_grid_3d().y-1) * Metal.threads_per_threadgroup_3d().y + Metal.thread_position_in_threadgroup_3d().y
 					A[ix,iy] = A[ix,iy] * A[ix,iy];
 				    return
 				end
-				A.data.=3;                 @roc gridsize=size(A) matsquare2D_AMDGPU!(A); AMDGPU.synchronize(); @test all(Base.Array(A.data) .== 9)
-				J.data.=3; J_ref.data.=36; @roc gridsize=size(J) matsquare2D_AMDGPU!(J); AMDGPU.synchronize(); @test AMDGPU.@allowscalar all(J .== J_ref)
-				C.data.=2; G.data.=3;      @roc gridsize=size(C) add2D_AMDGPU!(C, G);    AMDGPU.synchronize(); @test all(Base.Array(C.data) .== 5)
+				A.data.=3;                 @metal groups=size(A) matsquare2D_Metal!(A); Metal.synchronize(); @test all(Base.Array(A.data) .== 9)
+				J.data.=3; J_ref.data.=36; @metal groups=size(J) matsquare2D_Metal!(J); Metal.synchronize(); @test Metal.@allowscalar all(J .== J_ref)
+				C.data.=2; G.data.=3;      @metal groups=size(C) add2D_Metal!(C, G);    Metal.synchronize(); @test all(Base.Array(C.data) .== 5)
 			end
         end;
 		@testset "cellsize" begin
@@ -293,38 +323,40 @@ end
 			@test blocklength(H) == 4
 		end;
     end;
-	@testset "3. Exceptions ($array_type arrays)" for (array_type, Array, CellArray) in zip(array_types, ArrayConstructors, CellArrayConstructors)
+	@testset "3. Exceptions ($array_type arrays)" begin
 		dims       = (2,3)
 		celldims   = (3,4)
-		T_Float64  = SMatrix{celldims..., Float64, prod(celldims)}
+		T_DataType  = SMatrix{celldims..., DataType, prod(celldims)}
 		T_Int32    = SMatrix{celldims...,   Int32, prod(celldims)}
-		T2_Float64 = MyFieldArray{Float64}
+		T2_DataType = MyFieldArray{DataType}
 		T2_Int32   = MyFieldArray{Int32}
-		A = CellArray{Float64}(undef, dims)
+		A = CellArray{DataType}(undef, dims)
 		B = CellArrays.CellArray{Int32,prod(dims)}(Array, undef, dims)
-		C = CellArray{T_Float64}(undef, dims)
+		C = CellArray{T_DataType}(undef, dims)
 		D = CellArray{T_Int32,prod(dims)}(undef, dims)
-		E = CellArray{T2_Float64}(undef, dims)
+		E = CellArray{T2_DataType}(undef, dims)
 		F = CellArray{T2_Int32,prod(dims)}(undef, dims)
-		G = CellArray{T_Float64,1}(undef, dims)
+		G = CellArray{T_DataType,1}(undef, dims)
 		H = CellArray{T_Int32,4}(undef, dims)
 		@test_throws TypeError CellArray{Array}(undef, dims)                                                                           # Error: TypeError (celltype T is restricted to `Cell` in the package)
-		@test_throws TypeError CellArray{MMatrix{celldims..., Float64, prod(celldims)}}(undef, dims)                                   # ...
+		@test_throws TypeError CellArray{MMatrix{celldims..., DataType, prod(celldims)}}(undef, dims)                                   # ...
 		@test_throws ArgumentError CellArray{MyMutableFieldArray}(undef, dims)                                                         # Error: the celltype, `T`, must be a bitstype.
-		@test_throws IncoherentArgumentError CellArrays.CellArray{Float64,2,0}(similar(A.data, Float32), A.dims)                # Error: eltype(data) must match eltype(T).
-		@test_throws IncoherentArgumentError CellArrays.CellArray{Int32,2,prod(dims)}(similar(B.data, Float64), B.dims)         # ...
-		@test_throws IncoherentArgumentError CellArrays.CellArray{T_Float64,2,0}(similar(C.data, Float32), C.dims)              # ...
+		@test_throws IncoherentArgumentError CellArrays.CellArray{DataType,2,0}(similar(A.data, Int64), A.dims)                # Error: eltype(data) must match eltype(T).
+		@test_throws IncoherentArgumentError CellArrays.CellArray{Int32,2,prod(dims)}(similar(B.data, DataType), B.dims)         # ...
+		@test_throws IncoherentArgumentError CellArrays.CellArray{T_DataType,2,0}(similar(C.data, Int64), C.dims)              # ...
 		@test_throws IncoherentArgumentError CellArrays.CellArray{T_Int32,2,prod(dims)}(similar(D.data, T_Int32), D.dims)       # ...
-		@test_throws IncoherentArgumentError CellArrays.CellArray{T2_Float64,2,0}(similar(E.data, Float32), E.dims)             # ...
+		@test_throws IncoherentArgumentError CellArrays.CellArray{T2_DataType,2,0}(similar(E.data, Int64), E.dims)             # ...
 		@test_throws IncoherentArgumentError CellArrays.CellArray{T2_Int32,2,prod(dims)}(similar(F.data, T2_Int32), F.dims)     # ...
-		@test_throws IncoherentArgumentError CellArrays.CellArray{T_Float64,2,1}(similar(G.data, Float32), G.dims)              # ...
+		@test_throws IncoherentArgumentError CellArrays.CellArray{T_DataType,2,1}(similar(G.data, Int64), G.dims)              # ...
 		@test_throws IncoherentArgumentError CellArrays.CellArray{T_Int32,2,4}(similar(H.data, T_Int32), H.dims)                # ...
-		@test_throws MethodError CellArrays.CellArray{Float64,2,0}(A.data[:], A.dims)                                           # Error: ndims(data) must be 3.
-		@test_throws MethodError CellArrays.CellArray{T_Float64,2,0}(C.data[:], C.dims)                                         # Error: ...
-		@test_throws MethodError CellArrays.CellArray{T2_Float64,2,0}(E.data[:], E.dims)                                        # Error: ...
-		@test_throws IncoherentArgumentError CellArrays.CellArray{Float64,2,0}(similar(A.data, Float64, (1,2,1)), A.dims)       # Error: size(data) must match (blocklen, prod(size(T), ceil(prod(dims)/blocklen)).
-		@test_throws IncoherentArgumentError CellArrays.CellArray{T_Float64,2,0}(similar(C.data, Float64, (1,2,1)), C.dims)     # ...
-		@test_throws IncoherentArgumentError CellArrays.CellArray{T2_Float64,2,0}(similar(E.data, Float64, (1,2,1)), E.dims)    # ...
-		@test_throws IncoherentArgumentError CellArrays.CellArray{SMatrix{(4,5)..., Float64, prod((4,5))},2,0}(C.data, C.dims)  # ...
+		@test_throws MethodError CellArrays.CellArray{DataType,2,0}(A.data[:], A.dims)                                           # Error: ndims(data) must be 3.
+		@test_throws MethodError CellArrays.CellArray{T_DataType,2,0}(C.data[:], C.dims)                                         # Error: ...
+		@test_throws MethodError CellArrays.CellArray{T2_DataType,2,0}(E.data[:], E.dims)                                        # Error: ...
+		@test_throws IncoherentArgumentError CellArrays.CellArray{DataType,2,0}(similar(A.data, DataType, (1,2,1)), A.dims)       # Error: size(data) must match (blocklen, prod(size(T), ceil(prod(dims)/blocklen)).
+		@test_throws IncoherentArgumentError CellArrays.CellArray{T_DataType,2,0}(similar(C.data, DataType, (1,2,1)), C.dims)     # ...
+		@test_throws IncoherentArgumentError CellArrays.CellArray{T2_DataType,2,0}(similar(E.data, DataType, (1,2,1)), E.dims)    # ...
+		@test_throws IncoherentArgumentError CellArrays.CellArray{SMatrix{(4,5)..., DataType, prod((4,5))},2,0}(C.data, C.dims)  # ...
 	end;
 end;
+
+end end 

--- a/test/test_CellArray.jl
+++ b/test/test_CellArray.jl
@@ -267,23 +267,23 @@ for DataType in TEST_PRECISIONS
 				J.data.=3; J_ref.data.=36; @cuda blocks=size(J) matsquare2D_CUDA!(J); CUDA.synchronize(); @test CUDA.@allowscalar all(J .== J_ref)
 				C.data.=2; G.data.=3;      @cuda blocks=size(C) add2D_CUDA!(C, G);    CUDA.synchronize(); @test all(Base.Array(C.data) .== 5)
 			end
-			# if array_type == "AMDGPU"
-			# 	function add2D_AMDGPU!(A, B)
-			# 	    ix = (AMDGPU.blockIdx().x-1) * AMDGPU.blockDim().x + AMDGPU.threadIdx().x
-			# 	    iy = (AMDGPU.blockIdx().y-1) * AMDGPU.blockDim().y + AMDGPU.threadIdx().y
-			# 	    A[ix,iy] = A[ix,iy] + B[ix,iy];
-			# 	    return
-			# 	end
-			# 	function matsquare2D_AMDGPU!(A)
-			# 	    ix = (AMDGPU.blockIdx().x-1) * AMDGPU.blockDim().x + AMDGPU.threadIdx().x
-			# 	    iy = (AMDGPU.blockIdx().y-1) * AMDGPU.blockDim().y + AMDGPU.threadIdx().y
-			# 		A[ix,iy] = A[ix,iy] * A[ix,iy];
-			# 	    return
-			# 	end
-			# 	A.data.=3;                 @roc gridsize=size(A) matsquare2D_AMDGPU!(A); AMDGPU.synchronize(); @test all(Base.Array(A.data) .== 9)
-			# 	J.data.=3; J_ref.data.=36; @roc gridsize=size(J) matsquare2D_AMDGPU!(J); AMDGPU.synchronize(); @test AMDGPU.@allowscalar all(J .== J_ref)
-			# 	C.data.=2; G.data.=3;      @roc gridsize=size(C) add2D_AMDGPU!(C, G);    AMDGPU.synchronize(); @test all(Base.Array(C.data) .== 5)
-			# end
+			if array_type == "AMDGPU"
+				function add2D_AMDGPU!(A, B)
+				    ix = (AMDGPU.blockIdx().x-1) * AMDGPU.blockDim().x + AMDGPU.threadIdx().x
+				    iy = (AMDGPU.blockIdx().y-1) * AMDGPU.blockDim().y + AMDGPU.threadIdx().y
+				    A[ix,iy] = A[ix,iy] + B[ix,iy];
+				    return
+				end
+				function matsquare2D_AMDGPU!(A)
+				    ix = (AMDGPU.blockIdx().x-1) * AMDGPU.blockDim().x + AMDGPU.threadIdx().x
+				    iy = (AMDGPU.blockIdx().y-1) * AMDGPU.blockDim().y + AMDGPU.threadIdx().y
+					A[ix,iy] = A[ix,iy] * A[ix,iy];
+				    return
+				end
+				A.data.=3;                 @roc gridsize=size(A) matsquare2D_AMDGPU!(A); AMDGPU.synchronize(); @test all(Base.Array(A.data) .== 9)
+				J.data.=3; J_ref.data.=36; @roc gridsize=size(J) matsquare2D_AMDGPU!(J); AMDGPU.synchronize(); @test AMDGPU.@allowscalar all(J .== J_ref)
+				C.data.=2; G.data.=3;      @roc gridsize=size(C) add2D_AMDGPU!(C, G);    AMDGPU.synchronize(); @test all(Base.Array(C.data) .== 5)
+			end
 			if array_type == "Metal"
 				function add2D_Metal!(A, B)
 				    ix = (Metal.threadgroup_position_in_grid_3d().x-1) * Metal.threads_per_threadgroup_3d().x + Metal.thread_position_in_threadgroup_3d().x

--- a/test/test_CellArray.jl
+++ b/test/test_CellArray.jl
@@ -15,6 +15,7 @@ test_metal = Metal.functional()
 array_types           = ["CPU"]
 ArrayConstructors     = [Array]
 CellArrayConstructors = [CPUCellArray]
+precision_types       = [Float64]
 allowscalar_functions = Function[(x->x)]
 if test_cuda
 	cuzeros = CUDA.zeros
@@ -22,6 +23,7 @@ if test_cuda
 	push!(ArrayConstructors, CuArray)
 	push!(CellArrayConstructors, CuCellArray)
 	push!(allowscalar_functions, CUDA.allowscalar)
+	push!(precision_types, Float64)
 end
 if test_amdgpu
 	roczeros = AMDGPU.zeros
@@ -29,6 +31,7 @@ if test_amdgpu
 	push!(ArrayConstructors, ROCArray)
 	push!(CellArrayConstructors, ROCCellArray)
 	push!(allowscalar_functions, AMDGPU.allowscalar)
+  push!(precision_types, Float64)
 end
 if test_metal
 	metalzeros = Metal.zeros
@@ -36,6 +39,7 @@ if test_metal
 	push!(ArrayConstructors, MtlArray)
 	push!(CellArrayConstructors, MtlCellArray)
 	push!(allowscalar_functions, Metal.allowscalar)
+	push!(precision_types, Float32)
 end
 
 struct MyFieldArray{T} <: FieldArray{Tuple{2,2,2,2}, T, 4}
@@ -62,34 +66,29 @@ mutable struct MyMutableFieldArray{T} <: FieldArray{Tuple{2}, T, 1}
     yxxx::T
 end
 
-const TEST_PRECISIONS = [Float32, Float64]
-for (array_type, Array, CellArray, allowscalar) in zip(array_types, ArrayConstructors, CellArrayConstructors, allowscalar_functions)
-for DataType in TEST_PRECISIONS
-(array_type == "Metal" && DataType == Float64) ? continue : nothing # Metal does not support Float64
-
-@testset "$(basename(@__FILE__)) ($array_type arrays) (precision: $DataType)" begin
-    @testset "1. CellArray allocation ($array_type arrays) (precision: $DataType)" begin
+@testset "$(basename(@__FILE__)) ($array_type arrays) (precision: $Float)" for (array_type, Array, CellArray, allowscalar, Float) in zip(array_types, ArrayConstructors, CellArrayConstructors, allowscalar_functions, precision_types) 
+    @testset "1. CellArray allocation ($array_type arrays) (precision: $(nameof(Float))" begin
         @testset "Number cells" begin
 			dims = (2,3)
-			A = CellArray{DataType}(undef, dims)
+			A = CellArray{Float}(undef, dims)
 			B = CellArrays.CellArray{Int32,prod(dims)}(Array, undef, dims...)
-			C = CellArray{DataType,1}(undef, dims)
+			C = CellArray{Float,1}(undef, dims)
 			D = CellArray{Int32,4}(undef, dims)
 			@test typeof(A.data) <: Array
 			@test typeof(B.data) <: Array
 			@test typeof(C.data) <: Array
 			@test typeof(D.data) <: Array
-			@test eltype(A.data) == DataType
+			@test eltype(A.data) == Float
 			@test eltype(B.data) == Int32
-			@test eltype(C.data) == DataType
+			@test eltype(C.data) == Float
 			@test eltype(D.data) == Int32
-			@test eltype(A)      == DataType
+			@test eltype(A)      == Float
 			@test eltype(B)      == Int32
-			@test eltype(C)      == DataType
+			@test eltype(C)      == Float
 			@test eltype(D)      == Int32
-			@test typeof(A)      == CellArrays.CellArray{DataType, length(dims), 0, Array{eltype(A.data),_N}}
+			@test typeof(A)      == CellArrays.CellArray{Float, length(dims), 0, Array{eltype(A.data),_N}}
 			@test typeof(B)      == CellArrays.CellArray{Int32, length(dims), prod(dims), Array{eltype(B.data),_N}}
-			@test typeof(C)      == CellArrays.CellArray{DataType, length(dims), 1, Array{eltype(C.data),_N}}
+			@test typeof(C)      == CellArrays.CellArray{Float, length(dims), 1, Array{eltype(C.data),_N}}
 			@test typeof(D)      == CellArrays.CellArray{Int32, length(dims), 4, Array{eltype(D.data),_N}}
 			@test length(A.data) == prod(dims)
 			@test length(B.data) == prod(dims)
@@ -103,27 +102,27 @@ for DataType in TEST_PRECISIONS
 		@testset "SArray cells" begin
 			dims      = (2,3)
 			celldims  = (3,4)
-			T_DataType = SMatrix{celldims..., DataType, prod(celldims)}
+			T_Float = SMatrix{celldims..., Float, prod(celldims)}
 			T_Int32   = SMatrix{celldims...,   Int32, prod(celldims)}
-			A = CellArray{T_DataType}(undef, dims)
+			A = CellArray{T_Float}(undef, dims)
 			B = CellArrays.CellArray{T_Int32,prod(dims)}(Array, undef, dims...)
-			C = CellArray{T_DataType,1}(undef, dims)
+			C = CellArray{T_Float,1}(undef, dims)
 			D = CellArray{T_Int32,4}(undef, dims)
 			@test typeof(A.data) <: Array
 			@test typeof(B.data) <: Array
 			@test typeof(C.data) <: Array
 			@test typeof(D.data) <: Array
-			@test eltype(A.data) == DataType
+			@test eltype(A.data) == Float
 			@test eltype(B.data) == Int32
-			@test eltype(C.data) == DataType
+			@test eltype(C.data) == Float
 			@test eltype(D.data) == Int32
-			@test eltype(A)      == T_DataType
+			@test eltype(A)      == T_Float
 			@test eltype(B)      == T_Int32
-			@test eltype(C)      == T_DataType
+			@test eltype(C)      == T_Float
 			@test eltype(D)      == T_Int32
-			@test typeof(A)      == CellArrays.CellArray{T_DataType, length(dims), 0, Array{eltype(A.data),_N}}
+			@test typeof(A)      == CellArrays.CellArray{T_Float, length(dims), 0, Array{eltype(A.data),_N}}
 			@test typeof(B)      == CellArrays.CellArray{T_Int32, length(dims), prod(dims), Array{eltype(B.data),_N}}
-			@test typeof(C)      == CellArrays.CellArray{T_DataType, length(dims), 1, Array{eltype(C.data),_N}}
+			@test typeof(C)      == CellArrays.CellArray{T_Float, length(dims), 1, Array{eltype(C.data),_N}}
 			@test typeof(D)      == CellArrays.CellArray{T_Int32, length(dims), 4, Array{eltype(D.data),_N}}
 			@test length(A.data) == prod(dims)*prod(celldims)
 			@test length(B.data) == prod(dims)*prod(celldims)
@@ -137,27 +136,27 @@ for DataType in TEST_PRECISIONS
 		@testset "FieldArray cells" begin
 			dims      = (2,3)
 			celldims  = size(MyFieldArray)
-			T_DataType = MyFieldArray{DataType}
+			T_Float = MyFieldArray{Float}
 			T_Int32   = MyFieldArray{Int32}
-			A = CellArray{T_DataType}(undef, dims)
+			A = CellArray{T_Float}(undef, dims)
 			B = CellArrays.CellArray{T_Int32,prod(dims)}(Array, undef, dims...)
-			C = CellArray{T_DataType,1}(undef, dims)
+			C = CellArray{T_Float,1}(undef, dims)
 			D = CellArray{T_Int32,4}(undef, dims)
 			@test typeof(A.data) <: Array
 			@test typeof(B.data) <: Array
 			@test typeof(C.data) <: Array
 			@test typeof(D.data) <: Array
-			@test eltype(A.data) == DataType
+			@test eltype(A.data) == Float
 			@test eltype(B.data) == Int32
-			@test eltype(C.data) == DataType
+			@test eltype(C.data) == Float
 			@test eltype(D.data) == Int32
-			@test eltype(A)      == T_DataType
+			@test eltype(A)      == T_Float
 			@test eltype(B)      == T_Int32
-			@test eltype(C)      == T_DataType
+			@test eltype(C)      == T_Float
 			@test eltype(D)      == T_Int32
-			@test typeof(A)      == CellArrays.CellArray{T_DataType, length(dims), 0, Array{eltype(A.data),_N}}
+			@test typeof(A)      == CellArrays.CellArray{T_Float, length(dims), 0, Array{eltype(A.data),_N}}
 			@test typeof(B)      == CellArrays.CellArray{T_Int32, length(dims), prod(dims), Array{eltype(B.data),_N}}
-			@test typeof(C)      == CellArrays.CellArray{T_DataType, length(dims), 1, Array{eltype(C.data),_N}}
+			@test typeof(C)      == CellArrays.CellArray{T_Float, length(dims), 1, Array{eltype(C.data),_N}}
 			@test typeof(D)      == CellArrays.CellArray{T_Int32, length(dims), 4, Array{eltype(D.data),_N}}
 			@test length(A.data) == prod(dims)*prod(celldims)
 			@test length(B.data) == prod(dims)*prod(celldims)
@@ -172,17 +171,17 @@ for DataType in TEST_PRECISIONS
 	@testset "2. functions ($array_type arrays)" begin
 		dims      = (2,3)
 		celldims  = (3,4) # Needs to be compatible for matrix multiplication!
-		T_DataType = SMatrix{celldims..., DataType, prod(celldims)}
+		T_Float = SMatrix{celldims..., Float, prod(celldims)}
 		T_Int32   = SMatrix{celldims...,   Int32, prod(celldims)}
-		T2_DataType = MyFieldArray{DataType}
+		T2_DataType = MyFieldArray{Float}
 		T2_Int32   = MyFieldArray{Int32}
-		A = CellArray{DataType}(undef, dims)
+		A = CellArray{Float}(undef, dims)
 		B = CellArrays.CellArray{Int32,prod(dims)}(Array, undef, dims)
-		C = CellArray{T_DataType}(undef, dims)
+		C = CellArray{T_Float}(undef, dims)
 		D = CellArray{T_Int32,prod(dims)}(undef, dims)
 		E = CellArray{T2_DataType}(undef, dims)
 		F = CellArray{T2_Int32,prod(dims)}(undef, dims)
-		G = CellArray{T_DataType,1}(undef, dims)
+		G = CellArray{T_Float,1}(undef, dims)
 		H = CellArray{T_Int32,4}(undef, dims)
         @testset "size" begin
 			@test size(A) == dims
@@ -216,11 +215,11 @@ for DataType in TEST_PRECISIONS
 			allowscalar() do
 				fill!(A, 9);   @test all(Base.Array(A.data) .== 9.0)
 				fill!(B, 9.0); @test all(Base.Array(B.data) .== 9)
-				fill!(C, (1:length(eltype(C)))); @test all(C .== (T_DataType(1:length(eltype(C)))  for i=1:dims[1], j=1:dims[2]))
+				fill!(C, (1:length(eltype(C)))); @test all(C .== (T_Float(1:length(eltype(C)))  for i=1:dims[1], j=1:dims[2]))
 				fill!(D, (1:length(eltype(D)))); @test all(D .== (T_Int32(1:length(eltype(D)))    for i=1:dims[1], j=1:dims[2]))
 				fill!(E, (1:length(eltype(E)))); @test all(E .== (T2_DataType(1:length(eltype(E))) for i=1:dims[1], j=1:dims[2]))
 				fill!(F, (1:length(eltype(F)))); @test all(F .== (T2_Int32(1:length(eltype(F)))   for i=1:dims[1], j=1:dims[2]))
-				fill!(G, (1:length(eltype(G)))); @test all(G .== (T_DataType(1:length(eltype(G)))  for i=1:dims[1], j=1:dims[2]))
+				fill!(G, (1:length(eltype(G)))); @test all(G .== (T_Float(1:length(eltype(G)))  for i=1:dims[1], j=1:dims[2]))
 				fill!(H, (1:length(eltype(H)))); @test all(H .== (T_Int32(1:length(eltype(H)))    for i=1:dims[1], j=1:dims[2]))
 			end
 		end
@@ -229,19 +228,19 @@ for DataType in TEST_PRECISIONS
 				A.data.=0; B.data.=0; C.data.=0; D.data.=0; E.data.=0; F.data.=0; G.data.=0; H.data.=0;
 				A[2,2:3] .= 9
 				B[2,2:3] .= 9.0
-				C[2,2:3] .= (T_DataType(1:length(T_DataType)), T_DataType(1:length(T_DataType)))
+				C[2,2:3] .= (T_Float(1:length(T_Float)), T_Float(1:length(T_Float)))
 				D[2,2:3] .= (T_Int32(1:length(T_Int32)), T_Int32(1:length(T_Int32)))
 				E[2,2:3] .= (T2_DataType(1:length(T2_DataType)), T2_DataType(1:length(T2_DataType)))
 				F[2,2:3] .= (T2_Int32(1:length(T2_Int32)), T2_Int32(1:length(T2_Int32)))
-				G[2,2:3] .= (T_DataType(1:length(T_DataType)), T_DataType(1:length(T_DataType)))
+				G[2,2:3] .= (T_Float(1:length(T_Float)), T_Float(1:length(T_Float)))
 				H[2,2:3] .= (T_Int32(1:length(T_Int32)), T_Int32(1:length(T_Int32)))
 				@test all(A[2,2:3] .== 9.0)
 				@test all(B[2,2:3] .== 9)
-				@test all(C[2,2:3] .== (T_DataType(1:length(T_DataType)), T_DataType(1:length(T_DataType))))
+				@test all(C[2,2:3] .== (T_Float(1:length(T_Float)), T_Float(1:length(T_Float))))
 				@test all(D[2,2:3] .== (T_Int32(1:length(T_Int32)), T_Int32(1:length(T_Int32))))
 				@test all(E[2,2:3] .== (T2_DataType(1:length(T2_DataType)), T2_DataType(1:length(T2_DataType))))
 				@test all(F[2,2:3] .== (T2_Int32(1:length(T2_Int32)), T2_Int32(1:length(T2_Int32))))
-				@test all(G[2,2:3] .== (T_DataType(1:length(T_DataType)), T_DataType(1:length(T_DataType))))
+				@test all(G[2,2:3] .== (T_Float(1:length(T_Float)), T_Float(1:length(T_Float))))
 				@test all(H[2,2:3] .== (T_Int32(1:length(T_Int32)), T_Int32(1:length(T_Int32))))
 			end
         end;
@@ -326,37 +325,35 @@ for DataType in TEST_PRECISIONS
 	@testset "3. Exceptions ($array_type arrays)" begin
 		dims       = (2,3)
 		celldims   = (3,4)
-		T_DataType  = SMatrix{celldims..., DataType, prod(celldims)}
+		T_Float  = SMatrix{celldims..., Float, prod(celldims)}
 		T_Int32    = SMatrix{celldims...,   Int32, prod(celldims)}
-		T2_DataType = MyFieldArray{DataType}
+		T2_DataType = MyFieldArray{Float}
 		T2_Int32   = MyFieldArray{Int32}
-		A = CellArray{DataType}(undef, dims)
+		A = CellArray{Float}(undef, dims)
 		B = CellArrays.CellArray{Int32,prod(dims)}(Array, undef, dims)
-		C = CellArray{T_DataType}(undef, dims)
+		C = CellArray{T_Float}(undef, dims)
 		D = CellArray{T_Int32,prod(dims)}(undef, dims)
 		E = CellArray{T2_DataType}(undef, dims)
 		F = CellArray{T2_Int32,prod(dims)}(undef, dims)
-		G = CellArray{T_DataType,1}(undef, dims)
+		G = CellArray{T_Float,1}(undef, dims)
 		H = CellArray{T_Int32,4}(undef, dims)
 		@test_throws TypeError CellArray{Array}(undef, dims)                                                                           # Error: TypeError (celltype T is restricted to `Cell` in the package)
-		@test_throws TypeError CellArray{MMatrix{celldims..., DataType, prod(celldims)}}(undef, dims)                                   # ...
+		@test_throws TypeError CellArray{MMatrix{celldims..., Float, prod(celldims)}}(undef, dims)                                   # ...
 		@test_throws ArgumentError CellArray{MyMutableFieldArray}(undef, dims)                                                         # Error: the celltype, `T`, must be a bitstype.
-		@test_throws IncoherentArgumentError CellArrays.CellArray{DataType,2,0}(similar(A.data, Int64), A.dims)                # Error: eltype(data) must match eltype(T).
-		@test_throws IncoherentArgumentError CellArrays.CellArray{Int32,2,prod(dims)}(similar(B.data, DataType), B.dims)         # ...
-		@test_throws IncoherentArgumentError CellArrays.CellArray{T_DataType,2,0}(similar(C.data, Int64), C.dims)              # ...
+		@test_throws IncoherentArgumentError CellArrays.CellArray{Float,2,0}(similar(A.data, Int64), A.dims)                # Error: eltype(data) must match eltype(T).
+		@test_throws IncoherentArgumentError CellArrays.CellArray{Int32,2,prod(dims)}(similar(B.data, Float), B.dims)         # ...
+		@test_throws IncoherentArgumentError CellArrays.CellArray{T_Float,2,0}(similar(C.data, Int64), C.dims)              # ...
 		@test_throws IncoherentArgumentError CellArrays.CellArray{T_Int32,2,prod(dims)}(similar(D.data, T_Int32), D.dims)       # ...
 		@test_throws IncoherentArgumentError CellArrays.CellArray{T2_DataType,2,0}(similar(E.data, Int64), E.dims)             # ...
 		@test_throws IncoherentArgumentError CellArrays.CellArray{T2_Int32,2,prod(dims)}(similar(F.data, T2_Int32), F.dims)     # ...
-		@test_throws IncoherentArgumentError CellArrays.CellArray{T_DataType,2,1}(similar(G.data, Int64), G.dims)              # ...
+		@test_throws IncoherentArgumentError CellArrays.CellArray{T_Float,2,1}(similar(G.data, Int64), G.dims)              # ...
 		@test_throws IncoherentArgumentError CellArrays.CellArray{T_Int32,2,4}(similar(H.data, T_Int32), H.dims)                # ...
-		@test_throws MethodError CellArrays.CellArray{DataType,2,0}(A.data[:], A.dims)                                           # Error: ndims(data) must be 3.
-		@test_throws MethodError CellArrays.CellArray{T_DataType,2,0}(C.data[:], C.dims)                                         # Error: ...
+		@test_throws MethodError CellArrays.CellArray{Float,2,0}(A.data[:], A.dims)                                           # Error: ndims(data) must be 3.
+		@test_throws MethodError CellArrays.CellArray{T_Float,2,0}(C.data[:], C.dims)                                         # Error: ...
 		@test_throws MethodError CellArrays.CellArray{T2_DataType,2,0}(E.data[:], E.dims)                                        # Error: ...
-		@test_throws IncoherentArgumentError CellArrays.CellArray{DataType,2,0}(similar(A.data, DataType, (1,2,1)), A.dims)       # Error: size(data) must match (blocklen, prod(size(T), ceil(prod(dims)/blocklen)).
-		@test_throws IncoherentArgumentError CellArrays.CellArray{T_DataType,2,0}(similar(C.data, DataType, (1,2,1)), C.dims)     # ...
-		@test_throws IncoherentArgumentError CellArrays.CellArray{T2_DataType,2,0}(similar(E.data, DataType, (1,2,1)), E.dims)    # ...
-		@test_throws IncoherentArgumentError CellArrays.CellArray{SMatrix{(4,5)..., DataType, prod((4,5))},2,0}(C.data, C.dims)  # ...
+		@test_throws IncoherentArgumentError CellArrays.CellArray{Float,2,0}(similar(A.data, Float, (1,2,1)), A.dims)       # Error: size(data) must match (blocklen, prod(size(T), ceil(prod(dims)/blocklen)).
+		@test_throws IncoherentArgumentError CellArrays.CellArray{T_Float,2,0}(similar(C.data, Float, (1,2,1)), C.dims)     # ...
+		@test_throws IncoherentArgumentError CellArrays.CellArray{T2_DataType,2,0}(similar(E.data, Float, (1,2,1)), E.dims)    # ...
+		@test_throws IncoherentArgumentError CellArrays.CellArray{SMatrix{(4,5)..., Float, prod((4,5))},2,0}(C.data, C.dims)  # ...
 	end;
 end;
-
-end end 

--- a/test/test_CellArray.jl
+++ b/test/test_CellArray.jl
@@ -66,8 +66,8 @@ mutable struct MyMutableFieldArray{T} <: FieldArray{Tuple{2}, T, 1}
     yxxx::T
 end
 
-@testset "$(basename(@__FILE__)) ($array_type arrays) (precision: $Float)" for (array_type, Array, CellArray, allowscalar, Float) in zip(array_types, ArrayConstructors, CellArrayConstructors, allowscalar_functions, precision_types) 
-    @testset "1. CellArray allocation ($array_type arrays) (precision: $(nameof(Float))" begin
+@testset "$(basename(@__FILE__))" begin
+    @testset "1. CellArray allocation ($array_type arrays) (precision: $(nameof(Float))" for (array_type, Array, CellArray, allowscalar, Float) in zip(array_types, ArrayConstructors, CellArrayConstructors, allowscalar_functions, precision_types) 
         @testset "Number cells" begin
 			dims = (2,3)
 			A = CellArray{Float}(undef, dims)
@@ -168,18 +168,18 @@ end
 			@test D.dims         == dims
         end;
     end;
-	@testset "2. functions ($array_type arrays)" begin
+	@testset "2. functions ($array_type arrays) (precision: $(nameof(Float))" for (array_type, Array, CellArray, allowscalar, Float) in zip(array_types, ArrayConstructors, CellArrayConstructors, allowscalar_functions, precision_types) 
 		dims      = (2,3)
 		celldims  = (3,4) # Needs to be compatible for matrix multiplication!
 		T_Float = SMatrix{celldims..., Float, prod(celldims)}
 		T_Int32   = SMatrix{celldims...,   Int32, prod(celldims)}
-		T2_DataType = MyFieldArray{Float}
+		T2_Float = MyFieldArray{Float}
 		T2_Int32   = MyFieldArray{Int32}
 		A = CellArray{Float}(undef, dims)
 		B = CellArrays.CellArray{Int32,prod(dims)}(Array, undef, dims)
 		C = CellArray{T_Float}(undef, dims)
 		D = CellArray{T_Int32,prod(dims)}(undef, dims)
-		E = CellArray{T2_DataType}(undef, dims)
+		E = CellArray{T2_Float}(undef, dims)
 		F = CellArray{T2_Int32,prod(dims)}(undef, dims)
 		G = CellArray{T_Float,1}(undef, dims)
 		H = CellArray{T_Int32,4}(undef, dims)
@@ -217,7 +217,7 @@ end
 				fill!(B, 9.0); @test all(Base.Array(B.data) .== 9)
 				fill!(C, (1:length(eltype(C)))); @test all(C .== (T_Float(1:length(eltype(C)))  for i=1:dims[1], j=1:dims[2]))
 				fill!(D, (1:length(eltype(D)))); @test all(D .== (T_Int32(1:length(eltype(D)))    for i=1:dims[1], j=1:dims[2]))
-				fill!(E, (1:length(eltype(E)))); @test all(E .== (T2_DataType(1:length(eltype(E))) for i=1:dims[1], j=1:dims[2]))
+				fill!(E, (1:length(eltype(E)))); @test all(E .== (T2_Float(1:length(eltype(E))) for i=1:dims[1], j=1:dims[2]))
 				fill!(F, (1:length(eltype(F)))); @test all(F .== (T2_Int32(1:length(eltype(F)))   for i=1:dims[1], j=1:dims[2]))
 				fill!(G, (1:length(eltype(G)))); @test all(G .== (T_Float(1:length(eltype(G)))  for i=1:dims[1], j=1:dims[2]))
 				fill!(H, (1:length(eltype(H)))); @test all(H .== (T_Int32(1:length(eltype(H)))    for i=1:dims[1], j=1:dims[2]))
@@ -230,7 +230,7 @@ end
 				B[2,2:3] .= 9.0
 				C[2,2:3] .= (T_Float(1:length(T_Float)), T_Float(1:length(T_Float)))
 				D[2,2:3] .= (T_Int32(1:length(T_Int32)), T_Int32(1:length(T_Int32)))
-				E[2,2:3] .= (T2_DataType(1:length(T2_DataType)), T2_DataType(1:length(T2_DataType)))
+				E[2,2:3] .= (T2_Float(1:length(T2_Float)), T2_Float(1:length(T2_Float)))
 				F[2,2:3] .= (T2_Int32(1:length(T2_Int32)), T2_Int32(1:length(T2_Int32)))
 				G[2,2:3] .= (T_Float(1:length(T_Float)), T_Float(1:length(T_Float)))
 				H[2,2:3] .= (T_Int32(1:length(T_Int32)), T_Int32(1:length(T_Int32)))
@@ -238,7 +238,7 @@ end
 				@test all(B[2,2:3] .== 9)
 				@test all(C[2,2:3] .== (T_Float(1:length(T_Float)), T_Float(1:length(T_Float))))
 				@test all(D[2,2:3] .== (T_Int32(1:length(T_Int32)), T_Int32(1:length(T_Int32))))
-				@test all(E[2,2:3] .== (T2_DataType(1:length(T2_DataType)), T2_DataType(1:length(T2_DataType))))
+				@test all(E[2,2:3] .== (T2_Float(1:length(T2_Float)), T2_Float(1:length(T2_Float))))
 				@test all(F[2,2:3] .== (T2_Int32(1:length(T2_Int32)), T2_Int32(1:length(T2_Int32))))
 				@test all(G[2,2:3] .== (T_Float(1:length(T_Float)), T_Float(1:length(T_Float))))
 				@test all(H[2,2:3] .== (T_Int32(1:length(T_Int32)), T_Int32(1:length(T_Int32))))
@@ -322,18 +322,18 @@ end
 			@test blocklength(H) == 4
 		end;
     end;
-	@testset "3. Exceptions ($array_type arrays)" begin
+	@testset "3. Exceptions ($array_type arrays) (precision: $(nameof(Float))" for (array_type, Array, CellArray, allowscalar, Float) in zip(array_types, ArrayConstructors, CellArrayConstructors, allowscalar_functions, precision_types) 
 		dims       = (2,3)
 		celldims   = (3,4)
 		T_Float  = SMatrix{celldims..., Float, prod(celldims)}
 		T_Int32    = SMatrix{celldims...,   Int32, prod(celldims)}
-		T2_DataType = MyFieldArray{Float}
+		T2_Float = MyFieldArray{Float}
 		T2_Int32   = MyFieldArray{Int32}
 		A = CellArray{Float}(undef, dims)
 		B = CellArrays.CellArray{Int32,prod(dims)}(Array, undef, dims)
 		C = CellArray{T_Float}(undef, dims)
 		D = CellArray{T_Int32,prod(dims)}(undef, dims)
-		E = CellArray{T2_DataType}(undef, dims)
+		E = CellArray{T2_Float}(undef, dims)
 		F = CellArray{T2_Int32,prod(dims)}(undef, dims)
 		G = CellArray{T_Float,1}(undef, dims)
 		H = CellArray{T_Int32,4}(undef, dims)
@@ -344,16 +344,16 @@ end
 		@test_throws IncoherentArgumentError CellArrays.CellArray{Int32,2,prod(dims)}(similar(B.data, Float), B.dims)         # ...
 		@test_throws IncoherentArgumentError CellArrays.CellArray{T_Float,2,0}(similar(C.data, Int64), C.dims)              # ...
 		@test_throws IncoherentArgumentError CellArrays.CellArray{T_Int32,2,prod(dims)}(similar(D.data, T_Int32), D.dims)       # ...
-		@test_throws IncoherentArgumentError CellArrays.CellArray{T2_DataType,2,0}(similar(E.data, Int64), E.dims)             # ...
+		@test_throws IncoherentArgumentError CellArrays.CellArray{T2_Float,2,0}(similar(E.data, Int64), E.dims)             # ...
 		@test_throws IncoherentArgumentError CellArrays.CellArray{T2_Int32,2,prod(dims)}(similar(F.data, T2_Int32), F.dims)     # ...
 		@test_throws IncoherentArgumentError CellArrays.CellArray{T_Float,2,1}(similar(G.data, Int64), G.dims)              # ...
 		@test_throws IncoherentArgumentError CellArrays.CellArray{T_Int32,2,4}(similar(H.data, T_Int32), H.dims)                # ...
 		@test_throws MethodError CellArrays.CellArray{Float,2,0}(A.data[:], A.dims)                                           # Error: ndims(data) must be 3.
 		@test_throws MethodError CellArrays.CellArray{T_Float,2,0}(C.data[:], C.dims)                                         # Error: ...
-		@test_throws MethodError CellArrays.CellArray{T2_DataType,2,0}(E.data[:], E.dims)                                        # Error: ...
+		@test_throws MethodError CellArrays.CellArray{T2_Float,2,0}(E.data[:], E.dims)                                        # Error: ...
 		@test_throws IncoherentArgumentError CellArrays.CellArray{Float,2,0}(similar(A.data, Float, (1,2,1)), A.dims)       # Error: size(data) must match (blocklen, prod(size(T), ceil(prod(dims)/blocklen)).
 		@test_throws IncoherentArgumentError CellArrays.CellArray{T_Float,2,0}(similar(C.data, Float, (1,2,1)), C.dims)     # ...
-		@test_throws IncoherentArgumentError CellArrays.CellArray{T2_DataType,2,0}(similar(E.data, Float, (1,2,1)), E.dims)    # ...
+		@test_throws IncoherentArgumentError CellArrays.CellArray{T2_Float,2,0}(similar(E.data, Float, (1,2,1)), E.dims)    # ...
 		@test_throws IncoherentArgumentError CellArrays.CellArray{SMatrix{(4,5)..., Float, prod((4,5))},2,0}(C.data, C.dims)  # ...
 	end;
 end;

--- a/test/test_CellArray.jl
+++ b/test/test_CellArray.jl
@@ -67,7 +67,7 @@ mutable struct MyMutableFieldArray{T} <: FieldArray{Tuple{2}, T, 1}
 end
 
 @testset "$(basename(@__FILE__))" begin
-    @testset "1. CellArray allocation ($array_type arrays) (precision: $(nameof(Float))" for (array_type, Array, CellArray, allowscalar, Float) in zip(array_types, ArrayConstructors, CellArrayConstructors, allowscalar_functions, precision_types) 
+    @testset "1. CellArray allocation ($array_type arrays) (precision: $(nameof(Float)))" for (array_type, Array, CellArray, allowscalar, Float) in zip(array_types, ArrayConstructors, CellArrayConstructors, allowscalar_functions, precision_types) 
         @testset "Number cells" begin
 			dims = (2,3)
 			A = CellArray{Float}(undef, dims)
@@ -168,7 +168,7 @@ end
 			@test D.dims         == dims
         end;
     end;
-	@testset "2. functions ($array_type arrays) (precision: $(nameof(Float))" for (array_type, Array, CellArray, allowscalar, Float) in zip(array_types, ArrayConstructors, CellArrayConstructors, allowscalar_functions, precision_types) 
+	@testset "2. functions ($array_type arrays) (precision: $(nameof(Float)))" for (array_type, Array, CellArray, allowscalar, Float) in zip(array_types, ArrayConstructors, CellArrayConstructors, allowscalar_functions, precision_types) 
 		dims      = (2,3)
 		celldims  = (3,4) # Needs to be compatible for matrix multiplication!
 		T_Float = SMatrix{celldims..., Float, prod(celldims)}
@@ -322,7 +322,7 @@ end
 			@test blocklength(H) == 4
 		end;
     end;
-	@testset "3. Exceptions ($array_type arrays) (precision: $(nameof(Float))" for (array_type, Array, CellArray, allowscalar, Float) in zip(array_types, ArrayConstructors, CellArrayConstructors, allowscalar_functions, precision_types) 
+	@testset "3. Exceptions ($array_type arrays) (precision: $(nameof(Float)))" for (array_type, Array, CellArray, allowscalar, Float) in zip(array_types, ArrayConstructors, CellArrayConstructors, allowscalar_functions, precision_types) 
 		dims       = (2,3)
 		celldims   = (3,4)
 		T_Float  = SMatrix{celldims..., Float, prod(celldims)}

--- a/test/test_CellArray.jl
+++ b/test/test_CellArray.jl
@@ -28,14 +28,14 @@ if test_amdgpu
 	push!(array_types, "AMDGPU")
 	push!(ArrayConstructors, ROCArray)
 	push!(CellArrayConstructors, ROCCellArray)
-	push!(allowscalar_functions, AMDGPU.allowscalar) #TODO: to be implemented
+	push!(allowscalar_functions, AMDGPU.allowscalar)
 end
 if test_metal
 	metalzeros = Metal.zeros
 	push!(array_types, "Metal")
 	push!(ArrayConstructors, MtlArray)
 	push!(CellArrayConstructors, MtlCellArray)
-	push!(allowscalar_functions, Metal.allowscalar) #TODO: to be implemented
+	push!(allowscalar_functions, Metal.allowscalar)
 end
 
 struct MyFieldArray{T} <: FieldArray{Tuple{2,2,2,2}, T, 4}

--- a/test/test_CellArray.jl
+++ b/test/test_CellArray.jl
@@ -65,7 +65,7 @@ end
 const TEST_PRECISIONS = [Float32, Float64]
 for (array_type, Array, CellArray, allowscalar) in zip(array_types, ArrayConstructors, CellArrayConstructors, allowscalar_functions)
 for DataType in TEST_PRECISIONS
-(array_type == "Metal" && DataType == Float64) ? continue : nothing # Metal does not support DataType
+(array_type == "Metal" && DataType == Float64) ? continue : nothing # Metal does not support Float64
 
 @testset "$(basename(@__FILE__)) ($array_type arrays) (precision: $DataType)" begin
     @testset "1. CellArray allocation ($array_type arrays) (precision: $DataType)" begin


### PR DESCRIPTION
This PR adds support for Metal arrays in CellArray.jl, introducing the type `MtlCellArray` similarly to other GPUArrays.jl compatible backends.
